### PR TITLE
Add custom renderer for primitive value diffs

### DIFF
--- a/panel-ui.build.js
+++ b/panel-ui.build.js
@@ -50463,10 +50463,16 @@ module.exports={
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util__ = __webpack_require__(179);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_react__ = __webpack_require__(136);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_react___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2_react__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_inspector_ObjectLabel__ = __webpack_require__(176);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_inspector_ObjectLabel___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_inspector_ObjectLabel__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_inspector_ObjectRootLabel__ = __webpack_require__(175);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_inspector_ObjectRootLabel___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_inspector_ObjectRootLabel__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_ObjectName__ = __webpack_require__(113);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_ObjectName___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_ObjectName__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_ObjectValue__ = __webpack_require__(114);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_ObjectValue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_ObjectValue__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5_react_inspector_lib_object_inspector_ObjectLabel__ = __webpack_require__(176);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5_react_inspector_lib_object_inspector_ObjectLabel___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_5_react_inspector_lib_object_inspector_ObjectLabel__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6_react_inspector_lib_object_inspector_ObjectRootLabel__ = __webpack_require__(175);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6_react_inspector_lib_object_inspector_ObjectRootLabel___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_6_react_inspector_lib_object_inspector_ObjectRootLabel__);
+
+
 
 
 
@@ -50489,7 +50495,7 @@ const button = e('button');
 
 const nodeRenderer = (obj) => {
   const isRoot = obj.depth === 0;
-  const tag = isRoot ? __WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_inspector_ObjectRootLabel___default.a : __WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_inspector_ObjectLabel___default.a;
+  const tag = isRoot ? __WEBPACK_IMPORTED_MODULE_6_react_inspector_lib_object_inspector_ObjectRootLabel___default.a : __WEBPACK_IMPORTED_MODULE_5_react_inspector_lib_object_inspector_ObjectLabel___default.a;
   const append = isRoot ? {} : { isNonenumerable: obj.isNonenumerable };
   const keyMap = Object(__WEBPACK_IMPORTED_MODULE_0_ramda__["replace"])(/__(added|deleted)$/, '');
   const name = obj.name && keyMap(obj.name || '') || obj.name;
@@ -50499,7 +50505,7 @@ const nodeRenderer = (obj) => {
   );
 
   if (Object(__WEBPACK_IMPORTED_MODULE_1__util__["c" /* isModifiedObject */])(obj.data)) {
-    return e(tag, Object(__WEBPACK_IMPORTED_MODULE_0_ramda__["merge"])(append, { name, data: obj.data.__new }));
+    return e(diffObjectLabel, Object(__WEBPACK_IMPORTED_MODULE_0_ramda__["merge"])(append, { name, data: obj.data }));
   }
   if (Object(__WEBPACK_IMPORTED_MODULE_1__util__["b" /* isModifiedArray */])(obj.data)) {
     return e(tag, Object(__WEBPACK_IMPORTED_MODULE_0_ramda__["merge"])(append, { name, data: obj.data.filter(Object(__WEBPACK_IMPORTED_MODULE_0_ramda__["propEq"])('length', 2)) }));
@@ -50545,6 +50551,20 @@ const diffNodeMapper = ({ Arrow, expanded, styles, name, data, onClick, shouldSh
 };
 /* harmony export (immutable) */ __webpack_exports__["b"] = diffNodeMapper;
 
+
+/**
+ * Re-implements ObjectLabel to render a prettier diff for primitive values
+ */
+const diffObjectLabel = ({name, data, isNonenumerable}) => {
+  return span({}, [
+    e(__WEBPACK_IMPORTED_MODULE_3_react_inspector_lib_object_ObjectName___default.a, {name, dimmed: isNonenumerable}),
+    span({}, ': '),
+    e(__WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_ObjectValue___default.a, { object: data.__old }),
+    span({}, ' \u2192 '),
+    e(__WEBPACK_IMPORTED_MODULE_4_react_inspector_lib_object_ObjectValue___default.a, { object: data.__new })
+  ]);
+}
+/* unused harmony export diffObjectLabel */
 
 
 const formatDate = (ts) => {

--- a/view.js
+++ b/view.js
@@ -2,6 +2,8 @@ import { curry, replace, when, identity, propEq, pipe, keys, map, flip, zipObj, 
 import { isModifiedObject, isModifiedArray, disableEvent, handleDrop } from './util';
 
 import React, { Children } from 'react';
+import ObjectName from 'react-inspector/lib/object/ObjectName';
+import ObjectValue from 'react-inspector/lib/object/ObjectValue';
 import ObjectLabel from 'react-inspector/lib/object-inspector/ObjectLabel';
 import ObjectRootLabel from 'react-inspector/lib/object-inspector/ObjectRootLabel';
 
@@ -22,7 +24,7 @@ export const nodeRenderer = (obj) => {
   );
 
   if (isModifiedObject(obj.data)) {
-    return e(tag, merge(append, { name, data: obj.data.__new }));
+    return e(diffObjectLabel, merge(append, { name, data: obj.data }));
   }
   if (isModifiedArray(obj.data)) {
     return e(tag, merge(append, { name, data: obj.data.filter(propEq('length', 2)) }));
@@ -65,6 +67,18 @@ export const diffNodeMapper = ({ Arrow, expanded, styles, name, data, onClick, s
   ]);
 };
 
+/**
+ * Re-implements ObjectLabel to render a prettier diff for primitive values
+ */
+export const diffObjectLabel = ({name, data, isNonenumerable}) => {
+  return span({}, [
+    e(ObjectName, {name, dimmed: isNonenumerable}),
+    span({}, ': '),
+    e(ObjectValue, { object: data.__old }),
+    span({}, ' \u2192 '),
+    e(ObjectValue, { object: data.__new })
+  ]);
+}
 
 export const formatDate = (ts) => {
   const date = new Date(ts);


### PR DESCRIPTION
 Add custom renderer for primitive value diffs

- Changes the default renderer for primitive values, which just displays the new value, to one that shows the old value, an arrow, then the new value.
- This is quite ugly, could be improved greatly, and probably breaks things