### PR TITLE
Allow (sub)tree to be copied to clipboard as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
+    "copy-to-clipboard": "^3.0.8",
     "hjson": "^3.1.0",
     "json-diff": "^0.5.2",
     "ramda": "^0.25.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -155,21 +155,6 @@ html, body {
   transition: all 0.3s ease;
 }
 
-.model-diff.modified-key .object-name {
-  font-weight: bold;
-  color: #e0bb26 !important;
-}
-
-.model-diff.added-key .object-name {
-  font-weight: bold;
-  color: green !important;
-}
-
-.model-diff.deleted-key .object-name {
-  font-weight: bold;
-  color: red !important;
-}
-
 .time-toggle {
   cursor: pointer;
 }

--- a/src/MessageView.tsx
+++ b/src/MessageView.tsx
@@ -6,7 +6,7 @@ import { diff } from 'json-diff';
 import { SerializedMessage, Command } from './messaging';
 import { DependencyTrace, runDependencyTrace } from './dependency-trace';
 import { nextState, deepPick } from './util';
-import { nodeRenderer, diffNodeMapper } from './object-inspector';
+import { nodeRenderer, nodeMapper, diffNodeMapper } from './object-inspector';
 import { generateUnitTest } from './test-generator';
 import { MessageHeading } from './MessageHeading';
 
@@ -93,7 +93,7 @@ export class MessageView extends React.Component<Props, State> {
 
       const relayItem = Object.keys(relay).length > 0 ? [
         <div className="panel-label">Relay</div>,
-        <ObjectInspector data={relay} expandLevel={0} />
+        <ObjectInspector data={relay} expandLevel={0} mapper={nodeMapper} />
       ] : null;
 
       return (
@@ -105,7 +105,7 @@ export class MessageView extends React.Component<Props, State> {
           />
           <div className="message-properties">
             <div className="panel-label">Data</div>
-            <ObjectInspector data={data} expandLevel={0} />
+            <ObjectInspector data={data} expandLevel={0} mapper={nodeMapper} />
             {relayItem}
           </div>
         </div>
@@ -131,7 +131,7 @@ export class MessageView extends React.Component<Props, State> {
     const items = commands.map((command, index) => (
       <div className="command" key={index}>
         <div className="panel-label">{command[0]}</div>
-        <ObjectInspector data={command[1]} expandLevel={1} />
+        <ObjectInspector data={command[1]} expandLevel={1} mapper={nodeMapper} />
       </div>
     ));
 
@@ -153,7 +153,7 @@ export class MessageView extends React.Component<Props, State> {
     return (
       <div className="previous-state">
         <div className="panel-heading panel-label">Previous Model</div>
-        <ObjectInspector data={prev} expandLevel={2} />
+        <ObjectInspector data={prev} expandLevel={2} mapper={nodeMapper} />
       </div>
     );
   }
@@ -196,7 +196,7 @@ export class MessageView extends React.Component<Props, State> {
     return (
       <div className="next-state">
         <div className="panel-heading panel-label">New Model</div>
-        <ObjectInspector data={next} expandLevel={2} />
+        <ObjectInspector data={next} expandLevel={2} mapper={nodeMapper} />
       </div>
     );
   }

--- a/src/dependency-trace_test.ts
+++ b/src/dependency-trace_test.ts
@@ -1,4 +1,3 @@
-import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 import { dependencyTrace } from './dependency-trace';

--- a/src/object-inspector.scss
+++ b/src/object-inspector.scss
@@ -1,0 +1,51 @@
+.model-diff {
+    &.modified-key {
+        .object-name {
+            font-weight: bold;
+            color: #e0bb26 !important;
+        }
+    }
+
+    &.added-key {
+        .object-name {
+            font-weight: bold;
+            color: green !important;
+        }
+    }
+
+    &.deleted-key {
+        .object-name {
+            font-weight: bold;
+            color: red !important;
+        }
+    }
+}
+
+.mapped-node {
+    &-preview-container {
+        &:hover .copy-node-value {
+            display: inline-block;
+        }
+
+        .copy-node-value {
+            display: none;
+
+            font-size: 11px;
+            font-family: Menlo, monospace;
+            line-height: 13px;
+
+            padding: 0px 3px;
+            border-radius: 3px;
+            border: 1px solid #c3c3c3;
+            margin-left: 10px;
+
+            background-color: #f2f2f2;
+
+            cursor: pointer;
+
+            &:hover {
+                background-color: #e0e0e0;
+            }
+        }
+    }
+}

--- a/src/object-inspector_test.tsx
+++ b/src/object-inspector_test.tsx
@@ -77,3 +77,15 @@ describe('diffNodeMapper', () => {
     });
   });
 });
+
+describe('nodeMapper', () => {
+  it('displays a `copy` button on nested objects that copies JSON to clipboard', () => {
+    const wrapper = shallow(inspector.nodeMapper(obj));
+    expect(wrapper.find('CopyButton').exists()).to.equal(true);
+  });
+
+  it('does not display a `copy` button for primitive values', () => {
+    const wrapper = shallow(inspector.nodeMapper({ ...obj, data: 'test' }));
+    expect(wrapper.find('CopyButton').exists()).to.equal(false);
+  });
+});

--- a/types/react-inspector.d.ts
+++ b/types/react-inspector.d.ts
@@ -1,6 +1,10 @@
 declare module 'react-inspector' {
+  export interface NodeMapperOptions {
+    className: string;
+  }
+
   export type NodeRenderer<T> = (obj: ObjectNode<T>) => React.ReactElement;
-  export type NodeMapper<T> = (node: ObjectNode<T>) => React.ReactElement;
+  export type NodeMapper<T> = (node: ObjectNode<T>, options?: Partial<NodeMapperOptions>) => React.ReactElement;
 
   export interface ObjectNode<T extends {}> {
     Arrow: React.ReactElement;
@@ -30,4 +34,17 @@ declare module 'react-inspector' {
   export var ObjectInspector: React.ComponentClass<Props>;
   export var ObjectRootLabel: React.ComponentClass;
   export var ObjectLabel: React.ComponentClass;
+
+  interface ObjectNameProps {
+    name: string;
+    dimmed: boolean;
+  }
+
+  export var ObjectName: React.ComponentClass<ObjectNameProps>;
+
+  interface ObjectValueProps {
+    object?: {};
+  }
+
+  export var ObjectValue: React.ComponentClass<ObjectValueProps>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,12 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-to-clipboard@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 copy-webpack-plugin@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.4.1.tgz#1e8c366211db6dc2ddee40e5a3e4fc661dd149e8"
@@ -5279,6 +5285,10 @@ to-regex@^3.0.1:
     define-property "^0.2.5"
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 touch@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Depends on #15 

Displays a 'Copy' button when hovering over an object preview that allows a JSON representation of the object to be copied to the clipboard. This extends to nested Objects and Arrays, allowing sub-trees to be copied.

https://www.dropbox.com/s/ti42gsrks2l94ef/casium-dev-tools-copy-preview-2018-02-21_15.35.31?dl=0
