### PR TITLE
Improve rendering of primitive value diffs

### DIFF
--- a/src/object-inspector.tsx
+++ b/src/object-inspector.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as copy from 'copy-to-clipboard';
 import { both, flip, identity, keys, map, merge, pipe, propEq, replace, values, when, zipObj } from 'ramda';
-import { NodeRenderer, NodeMapper, ObjectRootLabel, ObjectLabel } from 'react-inspector';
+import { NodeRenderer, NodeMapper, ObjectRootLabel, ObjectLabel, ObjectName, ObjectValue } from 'react-inspector';
 
 import { isModifiedObject, isModifiedArray, typeOf } from './util';
 
@@ -28,7 +28,7 @@ export const nodeRenderer: NodeRenderer<ObjectDiffNode> = obj => {
   );
 
   if (isModifiedObject(obj.data)) {
-    return <Label {...append({ name, data: obj.data.__new }) } />
+    return <DiffObjectLabel {...append({ name, data: obj.data }) } />
   }
 
   if (isModifiedArray(obj.data)) {
@@ -48,6 +48,16 @@ export const nodeRenderer: NodeRenderer<ObjectDiffNode> = obj => {
 
   return <Label {...props} />;
 }
+
+const DiffObjectLabel: NodeRenderer<ObjectDiffNode> = ({ name, isNonenumerable, data }) => (
+  <span>
+    <ObjectName name={name} dimmed={isNonenumerable} />
+    <span>: </span>
+    <ObjectValue object={data.__old} />
+    <span>{' \u2192 '}</span>
+    <ObjectValue object={data.__new} />
+  </span>
+);
 
 export const diffNodeMapper: NodeMapper<ObjectDiffNode> = node => {
   let { styles, name, data, onClick, shouldShowPlaceholder, renderedNode } = node;
@@ -80,7 +90,7 @@ export const diffNodeMapper: NodeMapper<ObjectDiffNode> = node => {
   return nodeMapper(merge(node, { shouldShowPlaceholder }), { className });
 }
 
-export const CopyButton: React.StatelessComponent<{ data: any }> = ({ data }) => (
+const CopyButton: React.StatelessComponent<{ data: any }> = ({ data }) => (
   <button className="copy-node-value" onClick={e => {
     copy(JSON.stringify(data, null, 2));
     e.stopPropagation();
@@ -88,8 +98,6 @@ export const CopyButton: React.StatelessComponent<{ data: any }> = ({ data }) =>
     Copy
   </button>
 );
-
-CopyButton.displayName = 'CopyButton';
 
 export const nodeMapper: NodeMapper<any> = ({ shouldShowArrow, children, expanded, styles, shouldShowPlaceholder, Arrow, onClick, renderedNode, childNodes, data }, options = { className: '' }) => {
   const placeholder = (shouldShowArrow || React.Children.count(children) > 0) ?

--- a/src/object-inspector_test.tsx
+++ b/src/object-inspector_test.tsx
@@ -9,30 +9,32 @@ const obj = {
   depth: 0,
   renderedNode: 'TestNode',
   data: {
-    __old: 1,
-    __new: 2
+    count: {
+      __old: 1,
+      __new: 2
+    }
   },
   styles: {}
 } as any;
 
 describe('nodeRenderer', () => {
-  context('when `obj` is a modified root object', () => {
+  context('when `obj` is a root object', () => {
     it('renders an ObjectName and ObjectPreview', () => {
       const wrapper = shallow(inspector.nodeRenderer(obj));
       expect(wrapper.find('ObjectName').prop('name')).to.equal('test');
-      expect(wrapper.find('ObjectPreview').prop('data')).to.equal(2);
+      expect(wrapper.find('ObjectPreview').prop('data')).to.deep.equal(obj.data);
     })
   });
 
-  context('when `obj` is a modified non-root object', () => {
+  context('when `obj` is a non-root object', () => {
     it('renders an ObjectName and ObjectValue', () => {
       const wrapper = shallow(inspector.nodeRenderer({ ...obj, depth: 1 }));
       expect(wrapper.find('ObjectName').prop('name')).to.equal('test');
-      expect(wrapper.find('ObjectValue').prop('object')).to.equal(2);
+      expect(wrapper.find('ObjectValue').prop('object')).to.deep.equal(obj.data);
     })
   });
 
-  context('when `obj` is a modified root array', () => {
+  context('when `obj` is a root array', () => {
     it('renders an ObjectName and ObjectPreview', () => {
       const data = [['+', 'one'], ['+', 'two']];
 
@@ -42,23 +44,22 @@ describe('nodeRenderer', () => {
     })
   });
 
-  context('when `obj` is any other type', () => {
-    it('renders an ObjectName and ObjectPreview', () => {
-      const data = {
-        test: 'value'
-      };
+  context('when `obj` contains a modified primitive value', () => {
+    it('renders a diff of old value -> new value', () => {
+      const wrapper = shallow(inspector.nodeRenderer({ ...obj, data: obj.data.count }));
 
-      const wrapper = shallow(inspector.nodeRenderer({ ...obj, data }));
+      expect(wrapper.text()).to.equal('<ObjectName />: <ObjectValue /> \u2192 <ObjectValue />');
       expect(wrapper.find('ObjectName').prop('name')).to.equal('test');
-      expect(wrapper.find('ObjectPreview').prop('data')).to.deep.equal(data);
-    });
-  })
+      expect(wrapper.find('ObjectValue').at(0).prop('object')).to.equal(1);
+      expect(wrapper.find('ObjectValue').at(1).prop('object')).to.equal(2);
+    })
+  });
 });
 
 describe('diffNodeMapper', () => {
   context('when `object` is a modified object', () => {
     it('renders a model diff', () => {
-      const wrapper = shallow(inspector.diffNodeMapper(obj));
+      const wrapper = shallow(inspector.diffNodeMapper({ ...obj, data: obj.data.count }));
       expect(wrapper.find('.model-diff.modified').exists()).to.equal(true);
     });
   });


### PR DESCRIPTION
When rendering a primitive value in a diff, the object inspector now shows `oldValue -> newValue` to help in studying state changes.

![screenshot from 2018-02-21 17 19 37](https://user-images.githubusercontent.com/663716/36494936-82db1240-172b-11e8-80c8-0b8466778193.png)
