### PR TITLE
Improve Object and Array diff rendering

### DIFF
--- a/src/object-inspector.scss
+++ b/src/object-inspector.scss
@@ -1,19 +1,16 @@
 .model-diff {
-    &.modified-key {
-        .object-name {
-            font-weight: bold;
-            color: #e0bb26 !important;
-        }
-    }
-
-    &.added-key {
+    &.added-key.mapped-node-preview-container > span:nth-of-type(2),
+    &.added-key > li > .mapped-node > .mapped-node-preview-container > span:nth-of-type(2) {
         .object-name {
             font-weight: bold;
             color: green !important;
         }
     }
 
-    &.deleted-key {
+    &.deleted-key.mapped-node-preview-container > span:nth-of-type(2),
+    &.deleted-key > li > .mapped-node > .mapped-node-preview-container > span:nth-of-type(2) {
+        text-decoration: line-through;
+
         .object-name {
             font-weight: bold;
             color: red !important;

--- a/src/object-inspector.scss
+++ b/src/object-inspector.scss
@@ -1,19 +1,25 @@
 .model-diff {
-    &.added-key.mapped-node-preview-container > span:nth-of-type(2),
-    &.added-key > li > .mapped-node > .mapped-node-preview-container > span:nth-of-type(2) {
-        .object-name {
-            font-weight: bold;
-            color: green !important;
+    &.added-key.mapped-node-preview-container,
+    &.added-element > li > .mapped-node > .mapped-node-preview-container,
+    &.added-key > li > .mapped-node > .mapped-node-preview-container {
+        & > span:nth-of-type(2) {
+            .object-name {
+                font-weight: bold;
+                color: green !important;
+            }
         }
     }
 
-    &.deleted-key.mapped-node-preview-container > span:nth-of-type(2),
-    &.deleted-key > li > .mapped-node > .mapped-node-preview-container > span:nth-of-type(2) {
-        text-decoration: line-through;
+    &.deleted-key.mapped-node-preview-container,
+    &.deleted-element > li > .mapped-node > .mapped-node-preview-container,
+    &.deleted-key > li > .mapped-node > .mapped-node-preview-container {
+        & > span:nth-of-type(2) {
+            text-decoration: line-through;
 
-        .object-name {
-            font-weight: bold;
-            color: red !important;
+            .object-name {
+                font-weight: bold;
+                color: red !important;
+            }
         }
     }
 }

--- a/src/object-inspector.tsx
+++ b/src/object-inspector.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as copy from 'copy-to-clipboard';
 import { both, flip, identity, keys, map, merge, pipe, propEq, replace, values, when, zipObj } from 'ramda';
-import { NodeRenderer, NodeMapper, ObjectRootLabel, ObjectLabel, ObjectName, ObjectValue } from 'react-inspector';
+import { NodeRenderer, NodeMapper, ObjectRootLabel, ObjectLabel } from 'react-inspector';
 
 import { isModifiedObject, isModifiedArray, typeOf } from './util';
 
@@ -28,7 +28,7 @@ export const nodeRenderer: NodeRenderer<ObjectDiffNode> = obj => {
   );
 
   if (isModifiedObject(obj.data)) {
-    return <DiffObjectLabel {...append({ name, data: obj.data }) } />
+    return <Label {...append({ name, data: obj.data })} />
   }
 
   if (isModifiedArray(obj.data)) {
@@ -49,31 +49,19 @@ export const nodeRenderer: NodeRenderer<ObjectDiffNode> = obj => {
   return <Label {...props} />;
 }
 
-const DiffObjectLabel: NodeRenderer<ObjectDiffNode> = ({ name, isNonenumerable, data }) => (
-  <span>
-    <ObjectName name={name} dimmed={isNonenumerable} />
-    <span>: </span>
-    <ObjectValue object={data.__old} />
-    <span>{' \u2192 '}</span>
-    <ObjectValue object={data.__new} />
-  </span>
-);
-
 export const diffNodeMapper: NodeMapper<ObjectDiffNode> = node => {
-  let { styles, name, data, onClick, shouldShowPlaceholder, renderedNode } = node;
+  let { data, childNodes, name, shouldShowPlaceholder } = node;
 
   if (isModifiedObject(data)) {
-    const placeholder = shouldShowPlaceholder || true ? (
-      <span style={styles.treeNodePlaceholder}>
-        {PLACEHOLDER}
-      </span>
-    ) : null;
+    const [oldNode, newNode] = childNodes;
 
     return (
-      <div className="model-diff modified modified-key">
-        <div onClick={onClick}>
-          {placeholder}
-          {renderedNode}
+      <div>
+        <div className="model-diff deleted deleted-key">
+          {React.cloneElement(oldNode, { name })}
+        </div>
+        <div className="model-diff added added-key">
+          {React.cloneElement(newNode, { name })}
         </div>
       </div>
     );

--- a/src/object-inspector_test.tsx
+++ b/src/object-inspector_test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
@@ -8,6 +9,10 @@ const obj = {
   name: 'test',
   depth: 0,
   renderedNode: 'TestNode',
+  childNodes: [
+    <div id="oldNode" />,
+    <div id="newNode" />
+  ],
   data: {
     count: {
       __old: 1,
@@ -43,24 +48,14 @@ describe('nodeRenderer', () => {
       expect(wrapper.find('ObjectPreview').prop('data')).to.deep.equal(data);
     })
   });
-
-  context('when `obj` contains a modified primitive value', () => {
-    it('renders a diff of old value -> new value', () => {
-      const wrapper = shallow(inspector.nodeRenderer({ ...obj, data: obj.data.count }));
-
-      expect(wrapper.text()).to.equal('<ObjectName />: <ObjectValue /> \u2192 <ObjectValue />');
-      expect(wrapper.find('ObjectName').prop('name')).to.equal('test');
-      expect(wrapper.find('ObjectValue').at(0).prop('object')).to.equal(1);
-      expect(wrapper.find('ObjectValue').at(1).prop('object')).to.equal(2);
-    })
-  });
 });
 
 describe('diffNodeMapper', () => {
   context('when `object` is a modified object', () => {
-    it('renders a model diff', () => {
+    it('renders the `old` and `new` nodes directly, changing the `name` prop', () => {
       const wrapper = shallow(inspector.diffNodeMapper({ ...obj, data: obj.data.count }));
-      expect(wrapper.find('.model-diff.modified').exists()).to.equal(true);
+      expect(wrapper.find('#oldNode').prop('name')).to.equal('test');
+      expect(wrapper.find('#newNode').prop('name')).to.equal('test');
     });
   });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,8 +47,7 @@ export const isModifiedArray = both(
   pipe(
     map((val: any[]) => {
       return (typeOf(val) === 'array' && (
-        val.length === 2 && ['-', '+', '~'].includes(val[0]) ||
-        val.length === 1 && val[0] === ' '
+        val.length === 2 && ['-', '+', '~', ' '].includes(val[0])
       ));
     }),
     reduce<boolean, boolean>(and, true)

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -86,13 +86,13 @@ describe('isModifiedArray', () => {
     diff: [[], []],
     result: false
   }, {
-    diff: [[' ']],
+    diff: [[' ', 'unchangedElement'], ['+', 'addedElement']],
     result: true
   }, {
-    diff: [['+', ' ']],
+    diff: [['+', 'addedElement']],
     result: true
   }, {
-    diff: [['-', ' ']],
+    diff: [['-', 'deletedElement']],
     result: true
   }];
 


### PR DESCRIPTION
Greatly improved rendering of diffs. The 'oldValue' -> 'newValue' notation has been replaced with 'deleted' and 'added' lines, much more in keeping with traditional diffs.

## Examples:

Scalar -> Object and Scalar -> Array
![screenshot from 2018-02-26 16 12 35](https://user-images.githubusercontent.com/663716/36681200-e125d3ac-1b0f-11e8-85fa-6c88468ca101.png)

Object -> Scalar and Array deleted
![screenshot from 2018-02-26 16 13 31](https://user-images.githubusercontent.com/663716/36681245-ff42a612-1b0f-11e8-8a8b-355d40c570ba.png)

Array elements deleted and added
![screenshot from 2018-02-26 16 14 44](https://user-images.githubusercontent.com/663716/36681320-2c2bbb28-1b10-11e8-9643-2b3845fe9b4d.png)