### PR TITLE
Ignore test files and fix CodeClimate badge URLs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
 exclude_patterns:
+  - "**/*.d.ts"
   - "**/*_test.ts"
   - "**/*_test.tsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+exclude_patterns:
+  - "**/*_test.ts"
+  - "**/*_test.tsx"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dev Tools for Casium – An application architecture for React
 
-[![CircleCI](https://circleci.com/gh/ai-labs-team/casium-devtools.svg?style=svg)](https://circleci.com/gh/ai-labs-team/casium-devtools) [![Maintainability](https://api.codeclimate.com/v1/badges/4b7cb6dab31383dcff91/maintainability)](https://codeclimate.com/github/ai-labs-team/casium-devtools/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/4b7cb6dab31383dcff91/test_coverage)](https://codeclimate.com/github/ai-labs-team/casium-devtools/test_coverage)
+[![CircleCI](https://circleci.com/gh/ai-labs-team/casium-devtools.svg?style=svg)](https://circleci.com/gh/ai-labs-team/casium-devtools) [![Maintainability](https://api.codeclimate.com/v1/badges/d5e484d903bccb6175c1/maintainability)](https://codeclimate.com/github/ai-labs-team/casium-devtools/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/d5e484d903bccb6175c1/test_coverage)](https://codeclimate.com/github/ai-labs-team/casium-devtools/test_coverage)
 
 ## Installation & Development
 


### PR DESCRIPTION
CodeClimate is nerfing the maintainability rating due to unavoidable
duplication in test files, ignoring them should alleviate this.

Also, the badge URLs incorrectly pointed to my fork instead of the
canonical repo.