### PR TITLE
Firefox Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Replace values in manifest.json
           command: |
             cd /root/workspace/dist
-            jq '.version = "$CIRCLE_TAG"' manifest.json | sponge manifest.json
+            jq ".version = \"$CIRCLE_TAG\"" manifest.json | sponge manifest.json
             jq 'del(.version_name)' manifest.json | sponge manifest.json
             jq '.browser_action.default_icon = "icon.png"' manifest.json | sponge manifest.json
 
@@ -75,7 +75,7 @@ jobs:
             CURRENT_TIMESTAMP=`date +%s`
             JWT_HEADER=`printf %s {\"alg\": \"HS256\", \"typ\": \"JWT\"} | base64`
             JWT_PAYLOAD=`printf %s {\"iss\": \"$AMO_JWT_ISSUER\", \"jti\": \"$JWT_NONCE\", \"iat\": $CURRENT_TIMESTAMP, \"exp\": $(($CURRENT_TIMESTAMP + (5 * 60)))} | base64`
-            JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_SECRET | base64`
+            JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_JWT_SECRET | base64`
             JWT=$JWT_HEADER.$JWT_PAYLOAD.$JWT_SIGNATURE
 
             curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
       - run:
           name: Publish to AMO
           command: |
+            AMO_ID=eed25b73-3db7-4776-b7e8-bc3133a8ec5e
             JWT_NONCE=`dd if=/dev/urandom bs=20 count=1 2>/dev/null | openssl sha1`
             CURRENT_TIMESTAMP=`date +%s`
             JWT_HEADER=`printf %s {\"alg\": \"HS256\", \"typ\": \"JWT\"} | base64 | tr -d '\n'`
@@ -78,7 +79,7 @@ jobs:
             JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_JWT_SECRET | base64 | tr -d '\n'`
             JWT=$JWT_HEADER.$JWT_PAYLOAD.$JWT_SIGNATURE
 
-            curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG/" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"
+            curl "https://addons.mozilla.org/api/v3/addons/{$AMO_ID}/versions/$CIRCLE_TAG/" -g -XPUT -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,9 @@ jobs:
           command: |
             JWT_NONCE=`dd if=/dev/urandom bs=20 count=1 2>/dev/null | openssl sha1`
             CURRENT_TIMESTAMP=`date +%s`
-            JWT_HEADER=`printf %s {\"alg\": \"HS256\", \"typ\": \"JWT\"} | base64`
-            JWT_PAYLOAD=`printf %s {\"iss\": \"$AMO_JWT_ISSUER\", \"jti\": \"$JWT_NONCE\", \"iat\": $CURRENT_TIMESTAMP, \"exp\": $(($CURRENT_TIMESTAMP + (5 * 60)))} | base64`
-            JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_JWT_SECRET | base64`
+            JWT_HEADER=`printf %s {\"alg\": \"HS256\", \"typ\": \"JWT\"} | base64 | tr -d '\n'`
+            JWT_PAYLOAD=`printf %s {\"iss\": \"$AMO_JWT_ISSUER\", \"jti\": \"$JWT_NONCE\", \"iat\": $CURRENT_TIMESTAMP, \"exp\": $(($CURRENT_TIMESTAMP + (5 * 60)))} | base64 | tr -d '\n'`
+            JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_JWT_SECRET | base64 | tr -d '\n'`
             JWT=$JWT_HEADER.$JWT_PAYLOAD.$JWT_SIGNATURE
 
             curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG/" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_JWT_SECRET | base64`
             JWT=$JWT_HEADER.$JWT_PAYLOAD.$JWT_SIGNATURE
 
-            curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"
+            curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG/" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,18 @@ jobs:
           name: Publish to Chrome Store
           command: publish /root/workspace/casium-devtools.zip
 
+      - run:
+          name: Publish to AMO
+          command: |
+            JWT_NONCE=`dd if=/dev/urandom bs=20 count=1 2>/dev/null | openssl sha1`
+            CURRENT_TIMESTAMP=`date +%s`
+            JWT_HEADER=`printf %s {\"alg\": \"HS256\", \"typ\": \"JWT\"} | base64`
+            JWT_PAYLOAD=`printf %s {\"iss\": \"$AMO_JWT_ISSUER\", \"jti\": \"$JWT_NONCE\", \"iat\": $CURRENT_TIMESTAMP, \"exp\": $(($CURRENT_TIMESTAMP + (5 * 60)))} | base64`
+            JWT_SIGNATURE=`printf %s $JWT_HEADER.$JWT_PAYLOAD | openssl dgst -binary -sha256 -hmac $AMO_SECRET | base64`
+            JWT=$JWT_HEADER.$JWT_PAYLOAD.$JWT_SIGNATURE
+
+            curl "https://addons.mozilla.org/api/v3/addons/@casium-developer-tools/versions/$CIRCLE_TAG" -g -XPOST -F "upload=@/root/workspace/casium-devtools.zip" -H "Authorization: JWT $JWT"
+
 workflows:
   version: 2
   main:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
  - `yarn deps`
  - `yarn build`, or `yarn watch`, to auto-reload on saved changes
 
+### Chrome
+
  - Open [`chrome://extensions`](chrome://extensions)
  - Make sure `[✔] Developer Mode` is ✔'d
  - Click `Load unpacked extension...`
@@ -17,6 +19,17 @@
  - `⌘ + Opt + I` to initiate DevTools-ception
  - With Meta-DevTools window selected, `⌘ + R` to reload
  - You may need to also reload the inspected page
+
+### Firefox
+
+- Open [`about:debugging`](about:debugging)
+- Make sure `[✔] Enable add-on debugging` is ✔'d
+- Click `Load Temporary Add-on`
+- Select the `dist` directory
+- If the Inspector is open, close and reopen it
+
+- In the entry that appears for 'Casium Developer Tools', click the `Debug` button
+- Accept the remote debugging request
 
 ## Roadmap
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^15.6.1",
     "react-fontawesome": "^1.6.1",
     "react-inspector": "nateabele/react-inspector#master",
-    "title-case": "^2.1.1"
+    "title-case": "^2.1.1",
+    "webextension-polyfill": "^0.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.2",
@@ -59,6 +60,7 @@
     "typescript": "^2.7.1",
     "uglifyjs-webpack-plugin": "^1.2.0",
     "url-loader": "^0.6.2",
+    "web-ext-types": "^2.0.1",
     "webpack": "^3.5.5",
     "webpack-chrome-extension-reloader": "^0.7.0"
   },

--- a/src/App.scss
+++ b/src/App.scss
@@ -53,7 +53,7 @@ html, body {
 }
 .panel-label {
   color: rgb(97, 97, 97);
-  font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", sans-serif;
+  font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", Ubuntu, Arial, sans-serif;
   font-size: 12px;
   font-weight: bold;
 }
@@ -66,7 +66,10 @@ html, body {
   padding: 10px 15px;
   cursor: default;
   user-select: none;
+  font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", Ubuntu, Arial, sans-serif;
+  font-size: 12px;
 }
+
 .panel-item.selected {
   color: white;
   background: rgb(56, 121, 217);
@@ -75,22 +78,25 @@ html, body {
 .panel-tools {
   border-bottom: 1px solid lightgray;
   background: rgb(243, 243, 243);
-  height: 20px;
+  height: 25px;
+  vertical-align: top;
 }
 
 .panel-tools-right {
-  position: relative;
   display: inline-block;
-  top: -6px;
-  padding-left: 7px;
+  padding-left: 1px;
+  vertical-align: top;
 }
 
 .tool-button {
-  display: block;
-  float: left;
+  display: inline-block;
   background: rgb(243, 243, 243);
   cursor: pointer;
-  padding: 4px 6px;
+  width: 25px;
+  height: 25px;
+  line-height: 25px;
+  font-size: 12px;
+  text-align: center;
 }
 
 .tool-button:hover {
@@ -102,15 +108,33 @@ html, body {
 }
 
 .button-group {
+  display: inline-block;
   border-radius: 5px;
   border: 1px solid lightgray;
+  height: 21px;
+  margin-top: 1px;
 }
 
 .button-group button {
+  cursor: pointer;
+  font-size: 12px;
+  height: 21px;
+  vertical-align: middle;
+  width: 35px;
   font-weight: bold;
   border: 0;
   background: transparent;
   outline: 0;
+  color: black;
+  border-right: 1px solid lightgray;
+
+  &:hover {
+    background: lighten(lightgray, 10%);
+  }
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
 .button-group button.first {
@@ -118,8 +142,6 @@ html, body {
   border-bottom-left-radius: 5px;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-
-  border-right: 1px solid lightgray;
 }
 
 .button-group button.last {
@@ -128,11 +150,11 @@ html, body {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 
-  border-left: 1px solid lightgray;
+  border-right: none;
 }
 
 .button-group button:active, .button-group button.selected {
-  background: lightgray;
+  background: lighten(lightgray, 5%);
 }
 
 .unit-test-content {

--- a/src/MessageView.scss
+++ b/src/MessageView.scss
@@ -12,4 +12,16 @@
             padding-left: 10px;
         }
     }
+
+    // Ensures that object inspectors render nicely on off-white backgrounds
+    li {
+        background: transparent !important;
+    }
+
+    .diff-state {
+        em {
+            font-family: ".SFNSDisplay-Regular", "Helvetica Neue", "Lucida Grande", Ubuntu, Arial, sans-serif;
+            font-size: 12px;
+        }
+    }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,24 +1,23 @@
-// Chrome automatically creates a background.html page for this to execute.
+// Browser automatically creates a background.html page for this to execute.
 // This can access the inspected page via executeScript
 //
 // Can use:
-// chrome.tabs.*
-// chrome.extension.*
+// browser.tabs.*
+// browser.extension.*
 
-chrome.extension.onConnect.addListener(function(port) {
-
-  const extensionListener = function(message: any, sender: any, sendResponse: (response: any) => void) {
+browser.runtime.onConnect.addListener(port => {
+  const extensionListener = (message: any, sender: browser.runtime.MessageSender, sendResponse: (response?: any) => void) => {
     if (message.tabId) {
       if (message.action === 'code' && message.content) {
         // Evaluate script in inspectedPage
-        chrome.tabs.executeScript(message.tabId, { code: message.content });
+        browser.tabs.executeScript(message.tabId, { code: message.content });
       } else if (message.action === 'script' && message.content) {
         // Attach script to inspectedPage
-        chrome.tabs.executeScript(message.tabId, { file: message.content });
+        browser.tabs.executeScript(message.tabId, { file: message.content });
       } else {
         console.log("%c[Relaying Message]", "font-weight: bold; color: #e6b800;", message);
         // Pass message to inspectedPage
-        chrome.tabs.sendMessage(message.tabId, message, sendResponse);
+        browser.tabs.sendMessage(message.tabId, message).then(sendResponse);
       }
 
       // This accepts messages from the inspectedPage and
@@ -30,16 +29,15 @@ chrome.extension.onConnect.addListener(function(port) {
   }
 
   // Listens to messages sent from the panel
-  chrome.extension.onMessage.addListener(extensionListener);
+  browser.runtime.onMessage.addListener(extensionListener);
 
-  port.onDisconnect.addListener(function(port) {
-    chrome.extension.onMessage.removeListener(extensionListener);
+  port.onDisconnect.addListener(() => {
+    browser.runtime.onMessage.removeListener(extensionListener);
   });
 
-  port.onMessage.addListener(function(message) {
+  port.onMessage.addListener(message => {
     port.postMessage(message);
   });
-
 });
 
 const ports: typeof window.PORTS = window.PORTS = {};
@@ -51,7 +49,7 @@ const channels: { [key: string]: string } = {
 };
 
 // DevTools / page connection
-chrome.runtime.onConnect.addListener((port: any) => {
+browser.runtime.onConnect.addListener(port => {
 
   console.log("%c[Client Connected]: " + port.name, "font-weight: bold; color: #2eb82e;", port);
   ports[port.name] = port;
@@ -61,7 +59,7 @@ chrome.runtime.onConnect.addListener((port: any) => {
     queues[port.name] = [];
   }
 
-  const portListener = function(message: any, sender: any, sendResponse: (response: any) => void) {
+  const portListener = function(message: any, sender: browser.runtime.Port, sendResponse: (response?: any) => void) {
     console.log("%c[Client Message]: " + sender.name, "font-weight: bold; color: #e6b800;", message);
 
     if (!channels[sender.name]) {
@@ -80,15 +78,15 @@ chrome.runtime.onConnect.addListener((port: any) => {
     port.postMessage(message);
 
     if (message.tabId && message.scriptToInject) {
-      chrome.tabs.executeScript(message.tabId, { file: message.scriptToInject });
+      browser.tabs.executeScript(message.tabId, { file: message.scriptToInject });
     }
   }
 
   port.postMessage({ info: "Client connected to background", name: port.name });
 
   port.onDisconnect.addListener(function() {
-    port.onMessage.removeListener(portListener);
+    (port.onMessage.removeListener as any)(portListener);
     delete ports[port.name];
   });
-  port.onMessage.addListener(portListener);
+  (port.onMessage.addListener as any)(portListener);
 });

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -1,18 +1,17 @@
 // Executes on client page load
 (() => {
-  const port = chrome.extension.connect({ name: 'CasiumDevToolsPageScript' });
+  const port = browser.runtime.connect(undefined, { name: 'CasiumDevToolsPageScript' });
   const seen: string[] = [];
 
   // Get messages from background script
-  port.onMessage.addListener(function(msg, sender) {
-    // console.log("message to page script from " + sender.name, msg);
+  port.onMessage.addListener(function(msg) {
     window.postMessage(msg, '*');
   });
 
   port.postMessage({
     from: 'CasiumDevToolsPageScript',
     state: 'initialized'
-  }, "*");
+  });
 
   window.addEventListener('message', function(message) {
     if (!message || !message.data || !message.data.id || message.data.from === 'CasiumDevToolsPageScript') {
@@ -26,7 +25,7 @@
     }
 
     try {
-      port.postMessage(message.data, '*');
+      port.postMessage(message.data);
     } catch (e) {
       // Probably a cached version of this script trying to talk to a version of the extension
       // that no longer exists

--- a/src/dependency-trace.ts
+++ b/src/dependency-trace.ts
@@ -113,7 +113,7 @@ export const runDependencyTrace = (msg: SerializedMessage) => {
     `${JSON.stringify(msg.prev)} ,` +
     `${JSON.stringify(msg.data)} ,` +
     `${JSON.stringify(msg.relay)})` +
-    `//@ sourceURL=casium-devtools/run-dependency-trace.js`;
+    `//# sourceURL=casium-devtools/run-dependency-trace.js`;
 
   return new Promise<DependencyTrace>((resolve, reject) => {
     chrome.devtools.inspectedWindow.eval(evalString, (result: DependencyTrace, error) => {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -16,7 +16,7 @@ const createPanelIfCasiumLoaded = () => {
 
     clearInterval(loadCheckInterval);
     panelCreated = true;
-    chrome.devtools.panels.create('Casium', '', 'panel.html', () => { });
+    chrome.devtools.panels.create('Casium', 'icon.png', 'panel.html', () => { });
   });
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -27,18 +27,4 @@ declare global {
       }
     }
   }
-
-  // @types/chrome does not define `chrome.extension.connect()` or `chrome.extension.onConnect`
-  declare namespace chrome.extension {
-    declare var onConnect: typeof runtime.onConnect;
-    declare var onMessage: typeof runtime.onMessage;
-
-    export function connect(options: {}): {
-      onMessage: {
-        addListener(listener: (msg: any, sender: any) => void);
-      },
-
-      postMessage(options: {}, channels: string): void;
-    };
-  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,13 +10,17 @@
   },
   "background": {
     "scripts": [
+      "browser-polyfill.min.js",
       "background.js"
     ]
   },
   "content_scripts": [{
     "matches": ["http://*/*", "https://*/*"],
     "css": [],
-    "js": ["content-script.js"],
+    "js": [
+      "browser-polyfill.min.js",
+      "content-script.js"
+    ],
     "all_frames": true,
     "run_at": "document_idle"
   }],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Casium DevTools",
   "version": "0.0.0",
   "version_name": "dev-version",
-  "description": "A Chrome Developer Tools extension for debugging Casium state and messages",
+  "description": "A Developer Tools extension for debugging Casium state and messages.",
   "devtools_page": "devtools.html",
   "browser_action": {
     "default_icon": "icon-dev.png"

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -42,7 +42,7 @@ export type Listener = (msg: SerializedMessage) => any;
   const processMsg = (msg: SerializedMessage) =>
     ([predicate, ...listeners]: Listener[]) => predicate(msg) && listeners.map(l => l(msg));
 
-  const backgroundPageConnection = chrome.runtime.connect({ name: 'CasiumDevToolsPanel' });
+  const backgroundPageConnection = browser.runtime.connect(undefined, { name: 'CasiumDevToolsPanel' });
 
   backgroundPageConnection.onMessage.addListener((message: any) => {
     window.LISTENERS.length ? window.LISTENERS.forEach(processMsg(message)) : queue.push(message);
@@ -51,7 +51,7 @@ export type Listener = (msg: SerializedMessage) => any;
   window.messageClient = (data) => {
     backgroundPageConnection.postMessage(Object.assign({
       from: "CasiumDevToolsPanel",
-      tabId: chrome.devtools.inspectedWindow.tabId,
+      tabId: browser.devtools.inspectedWindow.tabId,
     }, data));
   }
 

--- a/src/object-inspector.scss
+++ b/src/object-inspector.scss
@@ -32,12 +32,13 @@
 
             font-size: 11px;
             font-family: Menlo, monospace;
-            line-height: 13px;
+            line-height: 12px;
 
             padding: 0px 3px;
             border-radius: 3px;
             border: 1px solid #c3c3c3;
             margin-left: 10px;
+            height: 14px;
 
             background-color: #f2f2f2;
 

--- a/src/panel.html
+++ b/src/panel.html
@@ -14,6 +14,7 @@
     </div>
   </div>
 
+  <script src="browser-polyfill.min.js" charset="utf-8"></script>
   <script src="messaging.js" charset="utf-8"></script>
   <script src="panel.js" charset="utf-8"></script>
 </body>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,10 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": [                            /* List of folders to include type definitions from. */
+      "node_modules/@types",
+      "node_modules/web-ext-types"
+    ],
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,12 +66,16 @@ module.exports = {
   },
 
   plugins: [
+    extractSass,
     isProd ? null : new ChromeExtensionReloader(),
     isProd ? new UglifyJsPlugin() : null,
-    extractSass,
-    new CopyWebpackPlugin([{ from: './src/*.png', flatten: true }]),
-    new CopyWebpackPlugin([{ from: './src/manifest.json', flatten: true }]),
-    new CopyWebpackPlugin([{ from: './src/devtools.html', flatten: true }]),
-    new CopyWebpackPlugin([{ from: './src/panel.html', flatten: true }]),
+    isProd ? null : new CopyWebpackPlugin([{ from: './node_modules/webextension-polyfill/dist/browser-polyfill.min.js.map', flatten: true }]),
+    new CopyWebpackPlugin([
+      { from: './src/*.png', flatten: true },
+      { from: './node_modules/webextension-polyfill/dist/browser-polyfill.min.js', flatten: true },
+      { from: './src/manifest.json', flatten: true },
+      { from: './src/devtools.html', flatten: true },
+      { from: './src/panel.html', flatten: true },
+    ]),
   ].filter(plugin => !!plugin)
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,6 +5598,14 @@ watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
+web-ext-types@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-ext-types/-/web-ext-types-2.0.1.tgz#eb311a15a922b459155aa7fef249cf6acf6ca402"
+
+webextension-polyfill@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.2.1.tgz#cdfc9126033039f1713553157d35beff1d4d6f4a"
+
 webpack-chrome-extension-reloader@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/webpack-chrome-extension-reloader/-/webpack-chrome-extension-reloader-0.7.0.tgz#428e5884dfb17af3307b234ba0411915a9a14e94"


### PR DESCRIPTION
The Chrome extension-specific code has now been replaced with code that is compliant with Mozilla's WebExtension spec. This spec is implemented by Firefox and Edge (IIRC), and a polyfill is used to make it work on on Chrome.

This allows us to target FF, Chrome and possibly Edge without any kind of conditional/branches build processes. The only variation is in publishing to the various repositories. This branch introduces an automated deployment to addons.mozilla.org (aka AMO) for all tags, in addition to the Chrome Web Store.

I've already created an AMO addon at https://addons.mozilla.org/en-GB/firefox/addon/casium-developer-tools/ - if anybody wants me to add their Mozilla accounts as a Developer or Admin, please let me know.

To support automatic publishing, the following environment variables need to be added on the CircleCI configuration page:

- `AMO_JWT_ISSUER`: The 'JWT issuer'
- `AMO_JWT_SECRET`: The 'JWT secret'

Both of these values are available after creating a Mozilla Developer
account, and then creating an API key at
https://addons.mozilla.org/en-GB/developers/addon/api/key/

Since I've already got these values from local testing, I can add them to the CircleCI config if somebody is able to give me admin permissions to do so.