### PR TITLE
Prevent/trap dependency trace failures

### DIFF
--- a/src/MessageView.tsx
+++ b/src/MessageView.tsx
@@ -89,7 +89,7 @@ export class MessageView extends React.Component<Props, State> {
     const items = selected.map((msg, index) => {
       const dependencyTrace = dependencyTraces[index];
       const relay = (useDependencyTrace && dependencyTrace) ? deepPick(msg.relay, dependencyTrace.relay) : msg.relay;
-      const data = (useDependencyTrace && dependencyTrace) ? deepPick(msg.data, dependencyTrace.message) : msg.data;
+      const data = (useDependencyTrace && dependencyTrace) ? deepPick(msg.data || {}, dependencyTrace.message) : msg.data || {};
 
       const relayItem = Object.keys(relay).length > 0 ? [
         <div className="panel-label">Relay</div>,
@@ -209,8 +209,11 @@ export class MessageView extends React.Component<Props, State> {
     return traces
       .then(dependencyTraces => {
         this.setState({ dependencyTraces });
-
         return dependencyTraces;
+      })
+      .catch(err => {
+        console.error('Failed to load dependency trace for selected messages', err);
+        return [];
       });
   }
 

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -20,7 +20,7 @@ export interface SerializedMessage {
   from: string;
   relay: any;
   message: string;
-  data: any;
+  data: {} | null;
   path: string[];
   commands?: Command[];
 }

--- a/src/test-generator.ts
+++ b/src/test-generator.ts
@@ -64,7 +64,7 @@ const messageNames = (pairs: MessageTracePair[]) =>
     }, '');
 
 const dispatchArg = ([msg, trace]: MessageTracePair) =>
-  `new ${msg.message}(${toJsVal(trace ? deepPick(msg.data, trace.message) : msg.data)})`;
+  `new ${msg.message}(${toJsVal(trace ? deepPick(msg.data || {}, trace.message) : msg.data)})`;
 
 const hasCommand = ([msg]: MessageTracePair) =>
   !!(msg.commands && msg.commands.length);


### PR DESCRIPTION
Fixes #23

When selecting an 'Init' message, some uncaught errors would cause the
Panel to appear unresponsive.

First, coerce `msg.data` to an object even when missing (as is the case
with Init messages and possibly other types) to prevent `deepPick` from
throwing.

Further, if the underlying eval throws an exception, then log it to the
console and return an empty trace result.

The eval fails and Unit Tests do not display the correct content
because the Message is described as the string `'Init (ContainerName)'`
which is not accurate as far as Casium is concerned. I'd like to refine
how Init messages are reported to the DevTools, but I'll work on that
once the currently overhaul as part of the Electron application is
completed.