### PR TITLE
Fix issues with deep model diffs and array changes

### DIFF
--- a/src/MessageView.tsx
+++ b/src/MessageView.tsx
@@ -12,6 +12,14 @@ import { MessageHeading } from './MessageHeading';
 
 import './MessageView.scss';
 
+/**
+ * When viewing an Object diff, expanded nodes cause rendering errors if the
+ * '__old' and '__new' values would appear 'below' the nesting boundary. To
+ * avoid this, use the awful hack of setting the default expand level to an
+ * artifically large number.
+ */
+const DIFF_EXPAND_LEVEL = 100;
+
 interface Props {
   selected: SerializedMessage[];
   showUnitTest?: boolean;
@@ -172,7 +180,7 @@ export class MessageView extends React.Component<Props, State> {
     const item = diffMap === undefined ? <em style={{ color: 'lightgray' }}>No Changes</em> : (
       <ObjectInspector
         data={diffMap}
-        expandLevel={3}
+        expandLevel={DIFF_EXPAND_LEVEL}
         nodeRenderer={nodeRenderer}
         mapper={diffNodeMapper}
       />

--- a/src/object-inspector_test.tsx
+++ b/src/object-inspector_test.tsx
@@ -72,12 +72,12 @@ describe('diffNodeMapper', () => {
         ...obj,
         data: [
           ['+', 4],
-          [' ', 8],
+          [' '],
           ['-', 15]
         ],
         childNodes: [
           <NodeStub id="node0" data={['+', 4]} />,
-          <NodeStub id="node1" data={[' ', 8]} />,
+          <NodeStub id="node1" data={[' ']} />,
           <NodeStub id="node2" data={['-', 15]} />
         ]
       }));

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,9 +46,10 @@ export const isModifiedArray = both(
   pipe(typeOf, equals('array')),
   pipe(
     map((val: any[]) => {
-      return (typeOf(val) === 'array' && (
-        val.length === 2 && ['-', '+', '~', ' '].includes(val[0])
-      ));
+      return typeOf(val) === 'array' && (
+        val.length === 2 && ['-', '+', '~'].includes(val[0]) ||
+        val.length === 1 && val[0] === ' '
+      );
     }),
     reduce<boolean, boolean>(and, true)
   )

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -86,7 +86,7 @@ describe('isModifiedArray', () => {
     diff: [[], []],
     result: false
   }, {
-    diff: [[' ', 'unchangedElement'], ['+', 'addedElement']],
+    diff: [[' '], ['+', 'addedElement']],
     result: true
   }, {
     diff: [['+', 'addedElement']],


### PR DESCRIPTION
When viewing a model diff where a modified property lived on the 'boundary' of the default expansion depth of '3', rendering errors would occur. Increasing the default expansion depth to 100 for model diffs acts as a (hacky) workaround.

Also fixes rendering of array changes; the format for unchanged array values was incorrectly assumed to be `[['+', 'newValue'], [' ','unchangedValue']]`, when in fact it should be `[['+', 'newValue'], [' ']]`.`

**Broken diff rendering for arrays (before)**
![screenshot from 2018-03-08 10 51 58](https://user-images.githubusercontent.com/663716/37147455-e36e592a-22be-11e8-931e-614c17fc6063.png)

**Fixed diff rendering for arrays (after)**
![screenshot from 2018-03-08 10 51 28](https://user-images.githubusercontent.com/663716/37147469-f7f94ae4-22be-11e8-8a78-574ab3f65927.png)

**Fixed diff rendering for deep objects (after)**
![screenshot from 2018-03-08 10 50 55](https://user-images.githubusercontent.com/663716/37147487-02bbe996-22bf-11e8-9425-e9b59a254332.png)
