### PR TITLE
Improve generated tests for containers that use `path`

### DIFF
--- a/src/dependency-trace.ts
+++ b/src/dependency-trace.ts
@@ -51,6 +51,19 @@ export const dependencyTrace = (context: string, name: string, model: {}, messag
     return true;
   };
 
+  const path = (path: string[], obj: { [key: string]: any }) => {
+    let val = obj;
+    let idx = 0;
+    while (idx < path.length) {
+      if (val == null) {
+        return;
+      }
+      val = val[path[idx]];
+      idx += 1;
+    }
+    return val;
+  }
+
   const archContext = window._ARCH_DEV_TOOLS_STATE.contexts[context];
   if (!archContext) {
     throw Error(`Context '${context}' does not exist`);
@@ -73,11 +86,11 @@ export const dependencyTrace = (context: string, name: string, model: {}, messag
   const messagePaths: string[][] = [];
   const relayPaths: string[][] = [];
 
-  const modelProxy = deepGetProxy(model, path => {
+  const modelProxy = deepGetProxy(path(archContext.path, model) || {}, path => {
     if (!modelPaths.find(existingPath => arrayEq(existingPath, path))) {
       modelPaths.push(path);
     }
-  });
+  }, archContext.path);
 
   const messageProxy = deepGetProxy(message, path => {
     if (!messagePaths.find(existingPath => arrayEq(existingPath, path))) {

--- a/src/dependency-trace.ts
+++ b/src/dependency-trace.ts
@@ -64,6 +64,12 @@ export const dependencyTrace = (context: string, name: string, model: {}, messag
     return val;
   }
 
+  /**
+   * Prevent an occasional and nasty 'Object couldn't be returned by value'
+   * error on Chrome
+   */
+  const serialize = (value: any) => JSON.parse(JSON.stringify(value));
+
   const archContext = window._ARCH_DEV_TOOLS_STATE.contexts[context];
   if (!archContext) {
     throw Error(`Context '${context}' does not exist`);
@@ -106,11 +112,11 @@ export const dependencyTrace = (context: string, name: string, model: {}, messag
 
   updater(modelProxy, messageProxy, relayProxy);
 
-  return {
+  return serialize({
     model: modelPaths,
     message: messagePaths,
     relay: relayPaths
-  };
+  });
 };
 
 /**

--- a/src/dependency-trace_test.ts
+++ b/src/dependency-trace_test.ts
@@ -38,7 +38,9 @@ describe('dependencyTrace()', () => {
                   count: relay.token.length > 0 && relay.token.length < 5 ? model.count + model.count + message.step : 0
                 })],
                 [{ name: 'IncrementCounter' }, (model: any, message: any) => ({ count: model.counter.count + message.step })],
-                [{ name: 'IncrementKeys' }, (model: any, message: any) => ({ count: model.count + Object.keys(message).length })]
+                [{ name: 'IncrementKeys' }, (model: any, message: any) => ({
+                  count: Object.keys(model).length + Object.keys(message).length
+                })]
               ])
             }
           },
@@ -105,6 +107,23 @@ describe('dependencyTrace()', () => {
       message: [
         ['step'],
         ['other']
+      ],
+      relay: []
+    });
+  });
+
+  it('stringifies Symbol keys', () => {
+    const trace = dependencyTrace('test', 'IncrementKeys', { count: 0, [Symbol.toStringTag]: 'CustomStateObject' }, { step: 1, other: 2, [Symbol.toStringTag]: 'CustomMessageObject' });
+
+    expect(trace).to.deep.equal({
+      model: [
+        ['count'],
+        ['Symbol(Symbol.toStringTag)']
+      ],
+      message: [
+        ['step'],
+        ['other'],
+        ['Symbol(Symbol.toStringTag)']
       ],
       relay: []
     });

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,6 +20,7 @@ declare global {
     _ARCH_DEV_TOOLS_STATE: {
       contexts: {
         [id: string]: {
+          path: string[],
           container: {
             update: Map<{ name: string }, (model: {}, message?: {}, relay?: {}) => void>
           }


### PR DESCRIPTION
Makes the dependency tracer and unit test generator more aware of 'container.path', and vastly reduces the amount of boilerplate rendered when generating tests under these circumstances.

Fixes #14 