### PR TITLE
Use Instrumentation API

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react-fontawesome": "^1.6.2",
     "@types/sinon": "^4.1.3",
     "awesome-typescript-loader": "^3.4.1",
-    "casium": "^1.0.11",
+    "casium": "2.0.1",
     "chai": "^4.1.2",
     "copy-webpack-plugin": "^4.4.1",
     "css-loader": "^0.28.9",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
+    "axios": "^0.18.0",
     "copy-to-clipboard": "^3.0.8",
+    "deep-freeze-strict": "^1.1.1",
+    "history": "^4.7.2",
     "hjson": "^3.1.0",
+    "js-cookie": "^2.2.0",
     "json-diff": "^0.5.2",
     "ramda": "^0.25.0",
     "react": "^15.6.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,11 +91,22 @@ export class App extends React.Component<{}, State> {
     ]);
 
     window.LISTENERS.push([
-      where({ from: equals('CasiumDevToolsPageScript'), state: equals('initialized') }),
+      where({ from: equals('CasiumDevToolsInstrumenter'), state: equals('initialized') }),
       () => this.state.active.replay && this.setState({ haltForReplay: true }),
       () => this.state.active.clearOnReload && this.clearMessages(),
       () => this.state.active.replay && window.messageClient({ selected: this.state.selected[0] }),
+      /**
+       * Notify the Instrumenter Backend(s) that the Panel is already initialized
+       * if the inspected page was reloaded
+       */
+      () => window.messageClient({ state: 'initialized' })
     ]);
+
+    /**
+     * Notify the Instrumenter Backend(s) that the Panel was initialized if it
+     * loaded *after* the inspected page
+     */
+    window.messageClient({ state: 'initialized' });
   }
 
   setActive<K extends keyof State['active']>(key: K, state: boolean) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as FontAwesome from 'react-fontawesome';
 import { concat, contains, equals, head, last, isNil, merge, slice, where } from 'ramda';
 
-import { SerializedMessage } from './messaging';
+import { SerializedMessage } from './instrumenter';
 import { download } from './util';
 import { importLog } from './import-log';
 import { MessageView } from './MessageView';
@@ -81,12 +81,12 @@ export class App extends React.Component<{}, State> {
 
   componentWillMount() {
     window.LISTENERS.push([
-      where({ from: equals('Arch'), state: isNil }),
+      where({ from: equals('CasiumDevToolsInstrumenter'), state: isNil }),
       message => !this.state.haltForReplay && this.setState({ messages: this.state.messages.concat(message) })
     ]);
 
     window.LISTENERS.push([
-      where({ from: equals('ArchDevToolsPanel'), state: isNil }),
+      where({ from: equals('CasiumDevToolsPanel'), state: isNil }),
       message => this.state.haltForReplay && this.setState({ haltForReplay: false })
     ]);
 
@@ -96,8 +96,6 @@ export class App extends React.Component<{}, State> {
       () => this.state.active.clearOnReload && this.clearMessages(),
       () => this.state.active.replay && window.messageClient({ selected: this.state.selected[0] }),
     ]);
-
-    window.FLUSH_QUEUE();
   }
 
   setActive<K extends keyof State['active']>(key: K, state: boolean) {
@@ -113,7 +111,7 @@ export class App extends React.Component<{}, State> {
 
   clearMessages() {
     this.setState({
-      messages: (window.MESSAGES = []),
+      messages: [],
       selected: [],
       haltForReplay: false,
       active: merge(this.state.active, { timeTravel: false, replay: false })

--- a/src/MessageHeading.tsx
+++ b/src/MessageHeading.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { SerializedMessage } from './messaging';
+import { SerializedMessage } from './instrumenter';
 
 const REFRESH_INTERVAL = 500;
 

--- a/src/MessageView.tsx
+++ b/src/MessageView.tsx
@@ -3,7 +3,7 @@ import { ObjectInspector } from 'react-inspector';
 import { unnest, identity, last, pluck } from 'ramda';
 import { diff } from 'json-diff';
 
-import { SerializedMessage, Command } from './messaging';
+import { SerializedMessage, SerializedCommand } from './instrumenter';
 import { DependencyTrace, runDependencyTrace } from './dependency-trace';
 import { nextState, deepPick } from './util';
 import { nodeRenderer, nodeMapper, diffNodeMapper } from './object-inspector';
@@ -129,7 +129,7 @@ export class MessageView extends React.Component<Props, State> {
   }
 
   protected _renderCommands() {
-    const commands = unnest<Command>((pluck as any)('commands', this.props.selected))
+    const commands = unnest<SerializedCommand>((pluck as any)('commands', this.props.selected))
       .filter(identity);
 
     if (!commands.length) {

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -8,7 +8,11 @@ const clientScript = document.createElement('script');
 clientScript.src = browser.extension.getURL('injected-script.js');
 (document.head || document.documentElement).appendChild(clientScript);
 
-const isAllowedPortSender = fromMatches(['CasiumDevToolsPanel']);
+const isAllowedPortSender = fromMatches([
+  'CasiumDevToolsPanel',
+  'CasiumDevToolsBackgroundScript'
+]);
+
 const isAllowedPostMessageSender = fromMatches(['CasiumDevToolsInstrumenter']);
 
 const port = browser.runtime.connect(undefined, { name: 'CasiumDevToolsPageScript' });

--- a/src/dependency-trace_test.ts
+++ b/src/dependency-trace_test.ts
@@ -2,10 +2,11 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import { dependencyTrace } from './dependency-trace';
+import { INSTRUMENTER_KEY } from './instrumenter';
 
 declare var global: {
   window: {
-    _ARCH_DEV_TOOLS_STATE: {
+    [INSTRUMENTER_KEY]: {
       contexts: {
         [key: string]: {
           path: string[];
@@ -25,7 +26,7 @@ const toggleUpdater = sinon.spy((flag: any) => ({
 describe('dependencyTrace()', () => {
   beforeEach(() => {
     global.window = {
-      _ARCH_DEV_TOOLS_STATE: {
+      [INSTRUMENTER_KEY]: {
         contexts: {
           test: {
             path: [],

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,8 +1,8 @@
+import { INSTRUMENTER_KEY } from './instrumenter';
+
 let panelCreated = false;
 
-const PAGE_HAS_CASIUM_EVAL = `!!(
-  Object.keys(window._ARCH_DEV_TOOLS_STATE.contexts).length
-)`;
+const PAGE_HAS_CASIUM_EVAL = `!!(window.${INSTRUMENTER_KEY}.stateManager)`;
 
 const createPanelIfCasiumLoaded = () => {
   if (panelCreated) {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,14 +3,6 @@ import { Listener } from './messaging';
 
 declare global {
   interface Window {
-    PORTS: {
-      [key: string]: browser.runtime.Port
-    },
-
-    QUEUES: {
-      [key: string]: browser.runtime.Port['postMessage'][]
-    },
-
     LISTENERS: Listener[][];
     messageClient: (data: any) => void;
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,31 +1,19 @@
-import { runtime } from 'chrome';
-
-import { SerializedMessage, Listener } from './messaging';
+import { INSTRUMENTER_KEY, Instrumenter } from './instrumenter';
+import { Listener } from './messaging';
 
 declare global {
   interface Window {
     PORTS: {
-      [key: string]: runtime.Port
-    };
+      [key: string]: browser.runtime.Port
+    },
 
     QUEUES: {
-      [key: string]: typeof runtime.Port.postmessage
-    };
+      [key: string]: browser.runtime.Port['postMessage'][]
+    },
 
-    MESSAGES: SerializedMessage[];
     LISTENERS: Listener[][];
-    FLUSH_QUEUE: () => void;
     messageClient: (data: any) => void;
 
-    _ARCH_DEV_TOOLS_STATE: {
-      contexts: {
-        [id: string]: {
-          path: string[],
-          container: {
-            update: Map<{ name: string }, (model: {}, message?: {}, relay?: {}) => void>
-          }
-        }
-      }
-    }
+    [INSTRUMENTER_KEY]: Instrumenter
   }
 }

--- a/src/import-log.ts
+++ b/src/import-log.ts
@@ -2,7 +2,7 @@ import { last } from 'ramda';
 
 import { upload } from './util';
 import { display } from './Notifier';
-import { SerializedMessage } from './messaging';
+import { SerializedMessage } from './instrumenter';
 
 /**
  * 'Replays' a message log by using the 'time travel' feature to set the

--- a/src/injected-script.ts
+++ b/src/injected-script.ts
@@ -1,0 +1,30 @@
+/**
+ * This script is injected and executed in the context of the inspected page via
+ * the Content Script. It initializes an Instrumenter backend that uses
+ * `window.postMessage` to relay messages to the Content Script.
+ */
+
+import { Instrumenter } from './instrumenter';
+import { fromMatches } from './util';
+
+const isAllowedSender = fromMatches([
+  'CasiumDevToolsPageScript',
+  'CasiumDevToolsPanel'
+]);
+
+new Instrumenter().addBackend('WebExtension', ({ connect, disconnect, send }) => {
+  window.addEventListener('message', ({ data }) => {
+    if (!isAllowedSender(data)) {
+      return;
+    }
+
+    if (data.state === 'initialized') {
+      connect();
+    }
+  })
+}, message => {
+  window.postMessage({
+    ...message,
+    from: 'CasiumDevToolsInstrumenter'
+  }, '*');
+})

--- a/src/instrumenter.ts
+++ b/src/instrumenter.ts
@@ -1,0 +1,127 @@
+import { onMessage, withStateManager, OnMessageCallback, StateManagerCallback } from 'casium/instrumentation';
+import { safeStringify, safeParse } from 'casium/util';
+import { GenericObject } from 'casium/core';
+import StateManager from 'casium/runtime/state_manager';
+import ExecContext, { cmdName } from 'casium/runtime/exec_context';
+import { filter, flatten, is, map, pipe } from 'ramda';
+
+export const INSTRUMENTER_KEY = '__CASIUM_DEV_TOOLS_INSTRUMENTER__';
+
+export interface Backend {
+  connected: boolean;
+  onMessage: (msg: SerializedMessage) => void;
+  queue: SerializedMessage[];
+}
+
+type ConnectionControl = {
+  connect: () => void;
+  disconnect: () => void;
+  send: (msg: any) => void;
+}
+
+export type SerializedCommand = [string, GenericObject];
+
+export interface SerializedMessage {
+  id: string;
+  name: string;
+  context: string;
+  ts: number;
+  prev: any;
+  next: any;
+  from: string;
+  relay: any;
+  message: string;
+  data: {} | null;
+  path: string[];
+  commands?: SerializedCommand[];
+}
+
+const serialize = map<GenericObject, GenericObject>(pipe(safeStringify, safeParse)) as any;
+
+const serializeCmds: (cmds: any[]) => SerializedCommand[] =
+  pipe(flatten as any, filter(is(Object)), map<any, SerializedCommand[]>(cmd => [cmdName(cmd), cmd.data]));
+
+/**
+ * The DevTools Instrumenter runs in the same context as the Inspected Page, and
+ * provides a pluggable 'backend' mechanism to allow multiple DevTools instances
+ * to connect simultaneously.
+ *
+ * This class acts as a Singleton; upon construction, it searches for an
+ * existing instance at `window[INSTRUMENTER_KEY]` and returns it if it already
+ * exists. Otherwise, a new instance is created and stored there.
+ */
+export class Instrumenter {
+  public stateManager?: StateManager;
+
+  public contexts: { [id: string]: ExecContext<any> } = {};
+
+  protected _backends: { [name: string]: Backend } = {};
+
+  protected _session = Date.now() + Math.random().toString(36).substr(2);
+
+  protected _messageCounter = 0;
+
+  constructor() {
+    if (window[INSTRUMENTER_KEY]) {
+      return window[INSTRUMENTER_KEY];
+    }
+
+    window[INSTRUMENTER_KEY] = this;
+    onMessage(this._instrumenterFn);
+    withStateManager(this._setRoot);
+  }
+
+  protected _instrumenterFn: OnMessageCallback = ({ context, msg, prev, next, path, cmds }) => {
+    const name = context.container && context.container.name || '{Anonymous Container}';
+
+    const serialized: SerializedMessage = serialize({
+      context: context.id,
+      id: this._session + this._nextId(),
+      ts: Date.now(),
+      relay: context.relay(),
+      message: msg && msg.constructor && msg.constructor.name || `Init (${name})`,
+      data: msg && msg.data,
+      commands: serializeCmds(cmds),
+      name,
+      prev,
+      next,
+      path,
+    });
+
+    this.contexts[context.id] = context;
+
+    for (const name in this._backends) {
+      const { connected, queue, onMessage } = this._backends[name];
+      connected ? onMessage(serialized) : queue.push(serialized);
+    }
+  };
+
+  protected _setRoot: StateManagerCallback = stateManager => {
+    this.stateManager = stateManager;
+  }
+
+  protected _nextId() {
+    return ++this._messageCounter;
+  }
+
+  public addBackend(name: string, control: (control: ConnectionControl) => void, onMessage: (message: SerializedMessage) => void) {
+    const backend = {
+      connected: false,
+      queue: [],
+      onMessage
+    };
+
+    control({
+      connect: () => {
+        backend.connected = true;
+        backend.queue.forEach(onMessage);
+        backend.queue = [];
+      },
+
+      disconnect: () => backend.connected = false,
+      send: () => { }
+    });
+
+    this._backends[name] = backend;
+  }
+}

--- a/src/instrumenter.ts
+++ b/src/instrumenter.ts
@@ -3,25 +3,39 @@ import { safeStringify, safeParse } from 'casium/util';
 import { GenericObject } from 'casium/core';
 import StateManager from 'casium/runtime/state_manager';
 import ExecContext, { cmdName } from 'casium/runtime/exec_context';
-import { filter, flatten, is, map, pipe } from 'ramda';
+import { filter, flatten, is, lensPath, map, pipe, set } from 'ramda';
 
 export const INSTRUMENTER_KEY = '__CASIUM_DEV_TOOLS_INSTRUMENTER__';
 
-export interface Backend {
+/**
+ * Used to retain the connectivity state and pending message queue for multiple
+ * Backends
+ */
+export type BackendState = {
   connected: boolean;
   onMessage: (msg: SerializedMessage) => void;
   queue: SerializedMessage[];
 }
 
-type ConnectionControl = {
+/**
+ * A Backend defines the in- and out-bound behaviour for interacting with the
+ * DevTools instrumenter. A Backend is defined as a function which accepts a
+ * `spec` object. This Spec contains the `connect`, `disconnect` and `send`
+ * functions, which allows the Backend to update its connectivity state stored
+ * within the Instrumenter.
+ *
+ * The Backend should return a function which will be called with a serialized
+ * form of a Message on every dispatch.
+ */
+export type Backend = (spec: {
   connect: () => void;
   disconnect: () => void;
   send: (msg: any) => void;
-}
+}) => (msg: SerializedMessage) => void;
 
 export type SerializedCommand = [string, GenericObject];
 
-export interface SerializedMessage {
+export type SerializedMessage = {
   id: string;
   name: string;
   context: string;
@@ -36,6 +50,10 @@ export interface SerializedMessage {
   commands?: SerializedCommand[];
 }
 
+export type InboundMessage = {
+  selected: SerializedMessage
+}
+
 const serialize = map<GenericObject, GenericObject>(pipe(safeStringify, safeParse)) as any;
 
 const serializeCmds: (cmds: any[]) => SerializedCommand[] =
@@ -45,22 +63,26 @@ const serializeCmds: (cmds: any[]) => SerializedCommand[] =
  * The DevTools Instrumenter runs in the same context as the Inspected Page, and
  * provides a pluggable 'backend' mechanism to allow multiple DevTools instances
  * to connect simultaneously.
- *
- * This class acts as a Singleton; upon construction, it searches for an
- * existing instance at `window[INSTRUMENTER_KEY]` and returns it if it already
- * exists. Otherwise, a new instance is created and stored there.
  */
 export class Instrumenter {
   public stateManager?: StateManager;
 
   public contexts: { [id: string]: ExecContext<any> } = {};
 
-  protected _backends: { [name: string]: Backend } = {};
+  protected _backendStates: { [name: string]: BackendState } = {};
 
   protected _session = Date.now() + Math.random().toString(36).substr(2);
 
   protected _messageCounter = 0;
 
+  /**
+  * This class acts as a Singleton; upon construction, it searches for an
+  * existing instance at `window[INSTRUMENTER_KEY]` and returns it if it already
+  * exists. Otherwise, a new instance is created and stored there.
+  *
+  * Uses the Instrumentation API to register an `onMessage` and
+  * `withStateManager` handler.
+  */
   constructor() {
     if (window[INSTRUMENTER_KEY]) {
       return window[INSTRUMENTER_KEY];
@@ -71,10 +93,15 @@ export class Instrumenter {
     withStateManager(this._setRoot);
   }
 
+  /**
+   * Whenever a Message is dispatched by Casium, turn it into a serializable
+   * form and send it to all connected backends.
+   */
   protected _instrumenterFn: OnMessageCallback = ({ context, msg, prev, next, path, cmds }) => {
     const name = context.container && context.container.name || '{Anonymous Container}';
 
     const serialized: SerializedMessage = serialize({
+      from: 'CasiumDevToolsInstrumenter',
       context: context.id,
       id: this._session + this._nextId(),
       ts: Date.now(),
@@ -90,12 +117,15 @@ export class Instrumenter {
 
     this.contexts[context.id] = context;
 
-    for (const name in this._backends) {
-      const { connected, queue, onMessage } = this._backends[name];
+    for (const name in this._backendStates) {
+      const { connected, queue, onMessage } = this._backendStates[name];
       connected ? onMessage(serialized) : queue.push(serialized);
     }
   };
 
+  /**
+   * Stores the root State Manager once the inspected page has initialized
+   */
   protected _setRoot: StateManagerCallback = stateManager => {
     this.stateManager = stateManager;
   }
@@ -104,24 +134,45 @@ export class Instrumenter {
     return ++this._messageCounter;
   }
 
-  public addBackend(name: string, control: (control: ConnectionControl) => void, onMessage: (message: SerializedMessage) => void) {
-    const backend = {
+  /**
+   * Registers a Backend against the Instrumenter. By default, the backend will
+   * be set to the `disconnected` state; the implementer must explcitly maintain
+   * connection state using `connect()` and `disconnect()`.
+   *
+   * Once the Backend has been registered a `{state: initialized}` message is
+   * emitted, which may be used for ensuring that downstream components are also
+   * initialized once the Instrumenter and Backend are ready.
+   */
+  public addBackend(name: string, backend: Backend) {
+    const onMessage = backend({
+      connect: () => {
+        state.connected = true;
+        state.queue.forEach(onMessage);
+        state.queue = [];
+      },
+
+      disconnect: () => state.connected = false,
+
+      send: (msg: InboundMessage) => {
+        if (msg.selected) {
+          const sel = msg.selected;
+          const newState = set(lensPath(sel.path), sel.next, sel.prev);
+          return withStateManager(stateManager => stateManager.set(newState));
+        }
+      }
+    });
+
+    const state = {
       connected: false,
       queue: [],
       onMessage
     };
 
-    control({
-      connect: () => {
-        backend.connected = true;
-        backend.queue.forEach(onMessage);
-        backend.queue = [];
-      },
+    this._backendStates[name] = state;
 
-      disconnect: () => backend.connected = false,
-      send: () => { }
-    });
-
-    this._backends[name] = backend;
+    onMessage({
+      from: 'CasiumDevToolsInstrumenter',
+      state: 'initialized'
+    } as any);
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,12 +22,15 @@
       "content-script.js"
     ],
     "all_frames": true,
-    "run_at": "document_idle"
+    "run_at": "document_start"
   }],
   "permissions": [
     "tabs",
     "http://*/*",
     "https://*/*"
+  ],
+  "web_accessible_resources": [
+    "injected-script.js"
   ],
   "manifest_version": 2
 }

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -6,3 +6,5 @@ import { Notifier } from './Notifier';
 
 render(createElement(App), document.getElementById('app'));
 render(createElement(Notifier), document.getElementById('notifier'));
+
+window.messageClient({ state: 'initialized' });

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -6,5 +6,3 @@ import { Notifier } from './Notifier';
 
 render(createElement(App), document.getElementById('app'));
 render(createElement(Notifier), document.getElementById('notifier'));
-
-window.messageClient({ state: 'initialized' });

--- a/src/test-generator.ts
+++ b/src/test-generator.ts
@@ -1,7 +1,7 @@
 import * as hjson from 'hjson';
 import { any, concat, head, keys, last, lensPath, mergeWith, pipe, set, uniq } from 'ramda';
 
-import { SerializedMessage, Command } from './messaging';
+import { SerializedMessage, SerializedCommand } from './instrumenter';
 import { DependencyTrace } from './dependency-trace';
 import { deepPick } from './util';
 
@@ -92,7 +92,7 @@ const containerDispatch = (pairs: MessageTracePair[]) => {
 const expectCommands = (pairs: MessageTracePair[]) => {
   const commands = pairs
     .filter(hasCommand)
-    .map(([msg]) => (msg.commands as Command[]).map(([name, data]) =>
+    .map(([msg]) => (msg.commands as SerializedCommand[]).map(([name, data]) =>
       `    new ${name}(${toJsVal(data)}),`
     ));
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
-import { and, both, equals, has, is, lensPath, map, merge, pipe, reduce, set, tail, view } from 'ramda';
+import { and, both, contains, equals, flip, has, is, lensPath, map, merge, pipe, propSatisfies, reduce, set, tail, view } from 'ramda';
 
-import { SerializedMessage } from './messaging';
+import { SerializedMessage } from './instrumenter';
 
 export interface DownloadOptions {
   filename: string;
@@ -126,3 +126,7 @@ export const deepPick = <T extends {}>(data: T, paths: string[][]): Partial<T> =
       return set(lens, value, result);
     }, {});
 
+const _contains = flip(contains);
+
+export const fromMatches = (senders: string[]) =>
+  propSatisfies(_contains(senders), 'from');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const extractSass = new ExtractTextPlugin({
 module.exports = {
   entry: {
     'content-script': './src/content-script.ts',
+    'injected-script': './src/injected-script.ts',
     'background': './src/background.ts',
     'devtools': './src/devtools.ts',
     'panel': './src/panel.ts',

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,9 +739,9 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-casium@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/casium/-/casium-1.0.11.tgz#2863d7afe55c05422e09e5f528a795a296aeeb3b"
+casium@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/casium/-/casium-2.0.1.tgz#362f78e6470c4a8a9b5f2b69db2e972e9d29a15f"
 
 center-align@^0.1.1:
   version "0.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,6 +359,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1321,6 +1328,10 @@ deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
 
+deep-freeze-strict@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze-strict/-/deep-freeze-strict-1.1.1.tgz#77d0583ca24a69be4bbd9ac2fae415d55523e5b0"
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
@@ -1919,6 +1930,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+follow-redirects@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
+
 font-awesome@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
@@ -2335,6 +2352,16 @@ he@1.1.1:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hjson@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/hjson/-/hjson-3.1.1.tgz#eaab95eebc6c0c749442219a817d9b4ff0070dd2"
@@ -2482,6 +2509,12 @@ ini@^1.3.4, ini@~1.3.0:
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
+invariant@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
 
 invariant@^2.2.2:
   version "2.2.2"
@@ -2856,6 +2889,10 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -3097,7 +3134,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4680,6 +4717,10 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -5572,6 +5613,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vendors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
@@ -5589,6 +5634,12 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Relocates the logic in the 'dev_tools' module of Casium core to an Instrumenter class.

An instance of this class is created in the same context as the inspected page by injecting `injected-script`.

The Instrumenter class has a concept of a 'backend', which is responsible for queuing pending messages when the DevTools are inactive, to ensure that messages are not lost. Backends are modular, to allow alternate communication channels in the future, such as WebSockets for a standalone DevTools application and/or command-line utilities.

There are also a few changes and cleanups to the messaging system, mainly to suit the Instrumenter implementation, but also to improve reliability of the connection to the inspected page.

---

As with the Core PR, I'm basing this against the `next` branch so that it can be released under a major version number.