### PR TITLE
Modify height of `.panel-container` to suit `.panel-tools`

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -12,7 +12,7 @@ html, body {
 
 .panel-container {
   display: flex;
-  height: calc(100% - 22px);
+  height: calc(100% - 26px);
 }
 
 .loading {


### PR DESCRIPTION
Prevents overall height of container exceeding 100%, which led to a superfluous scrollbar being displayed.

Fixes #32 