### PR TITLE
Fix message log import/export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,9 +205,7 @@ export class App extends React.Component<{}, State> {
               name="file-text-o"
               title="Save Message Log"
               className="tool-button save-msg-button"
-              onClick={() => {
-                download({ data: JSON.stringify(messages, null, 2), filename: 'message-log.json' });
-              }}
+              onClick={this._export}
             />
             <span
               className="fa-stack tool-button import-msg-button"
@@ -347,6 +345,16 @@ export class App extends React.Component<{}, State> {
     );
   }
 
+  protected _export = () =>
+    download({
+      data: JSON.stringify({
+        version: '1',
+        initial: this.state.initial,
+        messages: this.state.messages
+      }, null, 2),
+      filename: 'message-log.json'
+    })
+
   /**
    * Use `importLog` to replay a message log from a file on disk, then set
    * `state.messages` to display the Messages contained in the log, and reset
@@ -354,8 +362,9 @@ export class App extends React.Component<{}, State> {
    */
   protected _import = () =>
     importLog()
-      .then(messages => this.setState({
+      .then(({ initial, messages }) => this.setState({
+        initial,
         messages,
         selected: []
-      }))
+      }));
 }

--- a/src/App_test.tsx
+++ b/src/App_test.tsx
@@ -84,6 +84,8 @@ context('when a new message is received', () => {
   });
 });
 
+const initial = {};
+
 const messages = [{
   id: '0',
   message: '0',
@@ -225,13 +227,13 @@ describe('download button', () => {
     sinon.stub(util, 'download')
   });
 
-  it('downloads a JSON representation of message history on click', () => {
+  it('downloads a JSON representation of initial state and message history on click', () => {
     const wrapper = shallow(<App />);
-    wrapper.setState({ messages });
+    wrapper.setState({ initial, messages });
     wrapper.find('.save-msg-button').simulate('click');
 
     expect((util.download as sinon.SinonSpy).calledWith({
-      data: JSON.stringify(messages, null, 2),
+      data: JSON.stringify({ version: '1', initial, messages }, null, 2),
       filename: 'message-log.json'
     })).to.equal(true);
   });

--- a/src/import-log.ts
+++ b/src/import-log.ts
@@ -1,8 +1,5 @@
-import { last } from 'ramda';
-
-import { upload } from './util';
+import { applyDeltas, upload } from './util';
 import { display } from './Notifier';
-import { SerializedMessage } from './instrumenter';
 
 /**
  * 'Replays' a message log by using the 'time travel' feature to set the
@@ -11,24 +8,24 @@ import { SerializedMessage } from './instrumenter';
 export const importLog = () =>
   upload({ type: 'application/json' })
     .then(({ filename, content }) => {
-      const messages: SerializedMessage[] = JSON.parse(content);
+      const log: any = JSON.parse(content);
 
-      // Determine the last message for each path and replay it using Time Travel
-      const toReplay = last(messages);
+      if (log.version === '1') {
+        const { initial, messages } = log;
+        const setState = applyDeltas(initial, messages);
 
-      if (!toReplay) {
-        throw Error(`Log '${filename}' does not contain any replayable message(s)`);
+        window.messageClient({ setState });
+
+        display({
+          type: 'success',
+          title: 'Successfully replayed message log',
+          message: `Application state now matches the last message recorded in log '${filename}'`
+        });
+
+        return { initial, messages };
       }
 
-      window.messageClient({ selected: toReplay });
-
-      display({
-        type: 'success',
-        title: 'Successfully replayed message log',
-        message: `Application state now matches the last message recorded in log '${filename}'`
-      });
-
-      return messages;
+      throw new Error('Unknown Message Log format/version');
     })
     .catch(err => {
       display({

--- a/src/import-log_test.ts
+++ b/src/import-log_test.ts
@@ -11,41 +11,24 @@ declare var global: {
   }
 }
 
+const initial = {};
+
 const messages = [{
-  path: [],
-  prev: {},
-  next: {
-    counter: { value: 0 },
-    message: { title: '' }
-  }
+  id: '0',
+  message: '0',
+  delta: [[['counter'], 0], [['flag'], false]]
 }, {
-  path: ['counter'],
-  prev: {
-    counter: { value: 0 },
-    message: { title: '' }
-  },
-  next: { value: 10 }
+  id: '1',
+  message: '1',
+  delta: [[['counter'], 1]]
 }, {
-  path: ['message'],
-  prev: {
-    counter: { value: 10 },
-    message: { title: '' }
-  },
-  next: { title: 'hello' }
+  id: '2',
+  message: '2',
+  delta: [[['flag'], true]]
 }, {
-  path: ['counter'],
-  prev: {
-    counter: { value: 10 },
-    message: { title: 'hello' }
-  },
-  next: { value: 9 }
-}, {
-  path: ['message'],
-  prev: {
-    counter: { value: 9 },
-    message: { title: 'hello' }
-  },
-  next: { title: 'goodbye' }
+  id: '3',
+  message: '3',
+  delta: null
 }];
 
 describe('importLog', () => {
@@ -64,7 +47,11 @@ describe('importLog', () => {
 
     (util.upload as sinon.SinonStub).resolves({
       filename: 'messages.json',
-      content: JSON.stringify(messages)
+      content: JSON.stringify({
+        version: '1',
+        initial,
+        messages
+      })
     });
 
     importLog.importLog();
@@ -72,7 +59,10 @@ describe('importLog', () => {
     setImmediate(() => {
       expect(global.window.messageClient.args).to.deep.equal([
         [{
-          selected: messages[4]
+          setState: {
+            counter: 1,
+            flag: true
+          }
         }]
       ]);
 
@@ -127,7 +117,7 @@ describe('importLog', () => {
             type: 'error',
             title: 'Failed to replay message log',
             message: 'The file that you attempted to import could not be replayed:',
-            code: "Error: Log 'empty.json' does not contain any replayable message(s)"
+            code: 'Error: Unknown Message Log format/version'
           }]
         ]);
 


### PR DESCRIPTION
After the recent refactor to use a diff-based mechanism for state
changes, the message log import/export was sadly neglected. Now, the
initial state as well as a list of messages are exported.

In an effort to make the message log format more useful in the future,
I've also added a 'version' header, which is currently version '1'.
This gives us room to move around if we decide to change the message
log structure again.